### PR TITLE
fix: Properly deserialize vector length

### DIFF
--- a/lib/src/commonMain/kotlin/xyz/mcxross/bcs/internal/BcsDecoder.kt
+++ b/lib/src/commonMain/kotlin/xyz/mcxross/bcs/internal/BcsDecoder.kt
@@ -73,10 +73,7 @@ class BcsDecoder(
   override fun decodeSequentially(): Boolean = true
 
   override fun decodeCollectionSize(descriptor: SerialDescriptor): Int {
-    return inputBuffer.peek().toInt().also {
-      inputBuffer.skip(1)
-      elementsCount = it
-    }
+    return decodeUnit()
   }
 
   override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {

--- a/lib/src/commonTest/kotlin/xyz/mcxross/bcs/Serde.kt
+++ b/lib/src/commonTest/kotlin/xyz/mcxross/bcs/Serde.kt
@@ -34,4 +34,14 @@ class Serde {
     assertContentEquals(expected, encoding)
   }
 
+  @Test
+  fun canDecodeVectorOfLength128() {
+    val base = ByteArray(128) { it.toByte() }
+    val expectedLengthTag = listOf(0x80.toByte(), 0x01.toByte()).toByteArray()
+    val encoded = expectedLengthTag + base
+    val decoded = bcs.decodeFromByteArray<List<Byte>>(encoded)
+
+    val expected = base.toList()
+    assertContentEquals(expected, decoded)
+  }
 }


### PR DESCRIPTION
Vector length should be deserialized as a uleb128, per the bcs spec. 

Currently it is deserialized as a signed byte.

closes #1 